### PR TITLE
Fix for fdSocket (it's Socket -> IO CInt and it's deprecated)

### DIFF
--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -104,9 +104,13 @@ instance HasSocket Socket where
 ##if MIN_VERSION_network(3,1,0)
     withFdSocket_ = withFdSocket
 ##else
+##if MIN_VERSION_network(3,0,0)
     withFdSocket_ sock action = do
         fd <- fdSocket sock
         action fd
+##else
+    withFdSocket_ sock action = action (fdSocket sock)
+##endif
 ##endif
 
 ##ifdef __GLASGOW_HASKELL__


### PR DESCRIPTION
Hi,

I was trying to compile my project which uses Network.Socket.Options on Linux with ghc-8.4.2 and encountered an error saying that fdSocket has the signature of Socket -> IO CInt (not Socket -> CInt as the implementation assumed). I think this is connected with changes to Network module where the signature of fdSocket has changed since version 3.0. Never mind; I also noticed that these days they declare fdSocket as deprecated in favor of withFdSocket function, which is a brand new in network-3.1.0. This PR takes into account for the changed signature of fdSocket and uses the new withFdSocket when possible. The signature of fdSocket in older versions of network package is still respected.